### PR TITLE
fix `auth_data_type` in `NoAuth`

### DIFF
--- a/src/core/AuthConfig.h
+++ b/src/core/AuthConfig.h
@@ -1262,7 +1262,7 @@ namespace firebase
             this->data.clear();
             this->data.initialized = true;
             this->data.auth_type = auth_unknown_token;
-            this->data.auth_data_type = user_auth_data_undefined;
+            this->data.auth_data_type = user_auth_data_no_token;
         }
         user_auth_data &get() { return data; }
 


### PR DESCRIPTION
Currently the `NoAuth` class sets `auth_data_type` to `user_auth_data_undefined`, but the conditions for skipping authentication instead check for `user_auth_data_no_token`, which isn't set anywhere. See e.g. the following code:

https://github.com/mobizt/FirebaseClient/blob/76acb46b3b9e3966a870a6ef478ad993e7ed5d77/src/core/AsyncClient/AsyncClient.h#L527-L540

https://github.com/mobizt/FirebaseClient/blob/76acb46b3b9e3966a870a6ef478ad993e7ed5d77/src/database/RealtimeDatabase.h#L949-L950

The former causes `FIREBASE_ERROR_UNAUTHENTICATE` errors when `NoAuth` is used which doesn't make sense. The latter causes `?auth=<auth_token>` (with the placeholder) to be appended to URLs which seems to be incompatible with server-sent events.

Fix this by using `user_auth_data_no_token` instead.