### PR TITLE
Fix bugs in AsyncClient HTTP protocol and async task flow

### DIFF
--- a/src/core/AsyncClient/AsyncClient.h
+++ b/src/core/AsyncClient/AsyncClient.h
@@ -487,7 +487,8 @@ private:
         {
             if (state == async_state_send_header)
             {
-                if (sData->request.val[req_hndlr_ns::header].indexOf("Content-Length: 0\r\n") > -1)
+                // No payload when Content-Length is 0, or not set.
+                if (sData->request.val[req_hndlr_ns::header].indexOf("Content-Length: 0\r\n") > -1 || sData->request.val[req_hndlr_ns::header].indexOf("Content-Length") == -1)
                     sData->state = async_state_read_response;
                 else
                     sData->state = async_state_send_payload;

--- a/src/core/AsyncClient/AsyncClient.h
+++ b/src/core/AsyncClient/AsyncClient.h
@@ -1984,7 +1984,7 @@ private:
         {
             if (sData->async)
                 returnResult(sData, false);
-            reset(sData, false);
+            reset(sData, true);
         }
     }
 

--- a/src/core/AsyncClient/AsyncClient.h
+++ b/src/core/AsyncClient/AsyncClient.h
@@ -945,7 +945,7 @@ private:
         if (sData->response.flags.header_remaining)
         {
             int read = readLine(sData, sData->response.val[res_hndlr_ns::header]);
-            if ((read == 1 && sData->response.val[res_hndlr_ns::header][sData->response.val[res_hndlr_ns::header].length() - 1] == '\r') ||
+            if ((read == 1 && sData->response.val[res_hndlr_ns::header][sData->response.val[res_hndlr_ns::header].length() - 1] == '\n') ||
                 (read == 2 && sData->response.val[res_hndlr_ns::header][sData->response.val[res_hndlr_ns::header].length() - 2] == '\r' && sData->response.val[res_hndlr_ns::header][sData->response.val[res_hndlr_ns::header].length() - 1] == '\n'))
             {
                 sData->response.flags.http_response = true;

--- a/src/core/AsyncClient/AsyncClient.h
+++ b/src/core/AsyncClient/AsyncClient.h
@@ -2350,7 +2350,7 @@ private:
             handleEventTimeout(sData);
 #endif
 
-            if (!sData->sse && sData->return_type == function_return_type_complete)
+            if (!sData->sse && sData->return_type == function_return_type_complete && sData->state != async_state_send_payload)
                 sData->to_remove = true;
 
             if (sData->to_remove)


### PR DESCRIPTION
I came across several critical bugs while fixing errors in my project, and ended up needing to create a local fork for debugging and eventual resolution. This PR is the the result of that debugging, and it includes a few fixes to the way AsyncClient handles HTTP requests, as well as a few more minor edge cases that might be a result of my particular use case.

## 1. AsyncClient improperly parses `Transfer-Encoding: Chunked`

The `decodeChunks()` method in the AsyncClient does not adhere to [RFC9112](https://datatracker.ietf.org/doc/html/rfc9112#section-7.1), and thus introduces several bugs. For example, it does not properly count the bytes read (it counts the CLRFs included in the protocol, causing an incorrect count), and it also does not correctly handle the end of the chunked data, leaving bytes unread and, in my case, causing the client to attempt to keep reading past the end of the stream.

I was even encountering HTML in my responses, from Firebase complaining about malformed requests. I think this was due to the constant attempts by the library to read more data than was available on the socket.

I have refactored the implementation to properly handle the chunked data and leave no bytes left available on the socket.

## 2. AsyncClient improperly parses HTTP headers

The current implementation checks for the end of HTTP headers by looking for a line ending in either `\r` or `\r\n`, which is incorrect:

> A sender **MUST NOT** generate a bare CR (a CR character not immediately followed by LF) within any protocol elements other than the content. ([RFC9112](https://datatracker.ietf.org/doc/html/rfc9112#section-2.2))

This logic results in reading parts of the payload as header, and/or missing the payload altogether. I have updated the `readHeader()`function to check for `\r\n` or  a bare `\n`character instead, which fixed many of the issues I was having.

## 3. AsyncClient deadlocks when `Content-Length` is missing
After successfully sending the full header, the`AsyncClient` determines whether to send the payload next, or skip to reading the response based on the presence of `Content-Length: 0` in the header:


https://github.com/mobizt/FirebaseClient/blob/7044413e96361fa32d7c521512428d992326fa8e/src/core/AsyncClient/AsyncClient.h#L488-L496


This assumes that the content length header will always be present, but `FirestoreBase::asyncRequest` only sets it when `payload.length() > 0`:

https://github.com/mobizt/FirebaseClient/blob/7044413e96361fa32d7c521512428d992326fa8e/src/firestore/FirestoreBase.h#L179-L183

This creates an edge case when performing a Firestore query such as:

```cpp
docs.get(aClient, Firestore::Parent(projectId), documentPath, GetDocumentOptions(), getResult);
```

where the client correctly sends the response to the server, but never reads the response. The client also appears to get into a broken state where errors, debug messages, etc., stop working properly, making it difficult to find the source of the issue.

The fix is simple, just update the logic so the `AsyncClient` skips to reading the payload when `Content-Length: 0` _or is not set in the header_. This immediately fixed the issue — the client no longer hangs.


## 4. WiFiClientSecure stalls when the connection is reset by peer

I’m using an ESP32-S3 and PlatformIO for my project, and unfortunately the `WiFiClientSecure` implementation included in the latest PlatformIO-supported Arduino libraries (`v2.0.17`) fails to recognize when the connection was closed by the peer. The underlying error message for this on the ESP32-S3 comes from mbedtls:

```
[1512960][E][ssl_client.cpp:37] _handle_error(): [send_ssl_data():382]: (-80) UNKNOWN ERROR CODE (0050)
```

Immediately followed by an error from FirebaseClient:

```
Error task: task_2957, msg: TCP send failed, code: -2
```

The error code, `0x0050`, indicates [the connection was reset by the peer](https://gist.github.com/erikcorry/b25bdcacf3e0086f8a2afb688420678e#file-mbedtls-errors-txt-L224), and should be reopened. This is well-documented in this repository already, but the solution is not so clear.

I went ahead and updated the logic for the `handleProcessError()` function to stop the connection when the client encounters an error, which seems to have solved things in my use case.

## 5. Slots are prematurely removed while still sending their payload

The code that determines whether a slot should be marked for removal has a bug:

https://github.com/mobizt/FirebaseClient/blob/7044413e96361fa32d7c521512428d992326fa8e/src/core/AsyncClient/AsyncClient.h#L2317-L2321

In the case where `sData-state == async_state_send_payload`, the slot is prematurely removed before its payload can be fully sent, and the program seems to hang on the `Connecting to server...` message in the logs, when in fact the operation has been effectively cancelled.

I wasn't sure what the 'right' way to fix this one was, as there's probably somewhere earlier in the control flow that would be more appropriate -- perhaps the code that handles writing the payload could set `sData->return_type` to `function_return_type_continue` if there's more payload to send, rather than guarding against the premature slot removal at the end of the `process()` function.


---

Ok, that's everything. These issue were difficult to track down, but I am happy to report that my device firmware finally seems to be stable, and all my Firestore queries are succeeding with no errors. I don't even seem to be having any more issues with `WifiClientSecure`, which is very encouraging.

I'm sure I made some mistakes and/or violated some style conventions etc., as I'm no expert in this particular codebase, so please feel free to make corrections as you see fit. 

Hope this proves to be helpful!