### PR TITLE
Fix invalid enum conversion for setNetworkMode on Arduino IDE 2.3.6

### DIFF
--- a/examples/RealtimeDatabase/StreamGSM/StreamGSM.ino
+++ b/examples/RealtimeDatabase/StreamGSM/StreamGSM.ino
@@ -114,12 +114,12 @@ bool initModem()
     }
 
     /**
-     * 2 Automatic
-     * 13 GSM Only
-     * 14 WCDMA Only
-     * 38 LTE Only
+       MODEM_NETWORK_AUTO = 2, //Auto
+        MODEM_NETWORK_GSM = 13, //GSM ONLY
+        MODEM_NETWORK_WCDMA = 14, // WCDMA
+        MODEM_NETWORK_LTE = 38, //LTE
      */
-    modem.setNetworkMode(38);
+    modem.setNetworkMode(MODEM_NETWORK_LTE);
     if (modem.waitResponse(10000L) != 1)
     {
         DBG(" setNetworkMode faill");


### PR DESCRIPTION
**This commit fixes a compilation error caused by passing a raw integer (38) to the setNetworkMode function, which expects a NetworkMode enum. The issue appeared due to stricter type checking in Arduino IDE version 2**.3.6.


**_Error in Arduino IDE 2.3.6_**
C:\Users\ABC\AppData\Local\Temp\.arduinoIDE-unsaved202552-23620-qlaymt.ku25\StreamGSM\StreamGSM.ino: In function 'bool initModem()':
C:\Users\ABC\AppData\Local\Temp\.arduinoIDE-unsaved202552-23620-qlaymt.ku25\StreamGSM\StreamGSM.ino:122:26: error: invalid conversion from 'int' to 'NetworkMode' [-fpermissive]
  122 |     modem.setNetworkMode(38);
      |                          ^~
      |                          |
      |                          int
In file included from C:\Users\ABC\Documents\Arduino\libraries\TinyGSM\src/TinyGsmClient.h:64,
                 from C:\Users\ABC\AppData\Local\Temp\.arduinoIDE-unsaved202552-23620-qlaymt.ku25\StreamGSM\StreamGSM.ino:57:
C:\Users\ABC\Documents\Arduino\libraries\TinyGSM\src/TinyGsmClientSIM7600.h:318:35: note:   initializing argument 1 of 'bool TinyGsmSim7600::setNetworkMode(NetworkMode)'
  318 |   bool setNetworkMode(NetworkMode mode) {
      |                       ~~~~~~~~~~~~^~~~
exit status 1

Compilation error: invalid conversion from 'int' to 'NetworkMode' [-fpermissive